### PR TITLE
fix-search

### DIFF
--- a/src/js/galleryFetch.js
+++ b/src/js/galleryFetch.js
@@ -85,6 +85,7 @@ function onFormElSubmit(e) {
   }
 
   galleryReset();
+  refs.formSelectGenreEl.value = "";
 
   newFilmsBandle
     .onFetchKeyWordFilms()
@@ -114,6 +115,7 @@ function onSelectChange(e) {
   };
 
   galleryReset();
+  refs.formEl.elements.searchQuery.value = "";
 
   newFilmsBandle
     .onFetchGenresFilms()


### PR DESCRIPTION
поправила отображение жанров и инпута формы - при запросе через список жанров обнуляется форма с названием. и, наоборот - при запросе по имени - обнуляется форма жанров. 

пагинацию пока не поправила